### PR TITLE
Set up Spring Boot bootstrap classes and Shopify configuration

### DIFF
--- a/Importacion_Etiquetas_Envio/pom.xml
+++ b/Importacion_Etiquetas_Envio/pom.xml
@@ -4,14 +4,109 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
     <groupId>org.TFG</groupId>
     <artifactId>Importacion_Etiquetas_Envio</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <name>Importacion_Etiquetas_Envio</name>
+    <description>Importación de etiquetas de envío Shopify</description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencies>
+        <!-- Backend Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+
+        <!-- Cliente de escritorio -->
+        <dependency>
+            <groupId>com.formdev</groupId>
+            <artifactId>flatlaf</artifactId>
+            <version>3.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.miglayout</groupId>
+            <artifactId>miglayout-swing</artifactId>
+            <version>11.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.5</version>
+        </dependency>
+
+        <!-- Utilidades comunes -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.32</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/Importacion_Etiquetas_Envio/src/main/java/org/tfg/importacion/ImportacionEtiquetasEnvioApplication.java
+++ b/Importacion_Etiquetas_Envio/src/main/java/org/tfg/importacion/ImportacionEtiquetasEnvioApplication.java
@@ -1,0 +1,12 @@
+package org.tfg.importacion;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ImportacionEtiquetasEnvioApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ImportacionEtiquetasEnvioApplication.class, args);
+    }
+}

--- a/Importacion_Etiquetas_Envio/src/main/java/org/tfg/importacion/config/ShopifyClientConfiguration.java
+++ b/Importacion_Etiquetas_Envio/src/main/java/org/tfg/importacion/config/ShopifyClientConfiguration.java
@@ -1,0 +1,23 @@
+package org.tfg.importacion.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@EnableConfigurationProperties(ShopifyProperties.class)
+public class ShopifyClientConfiguration {
+
+    @Bean
+    public WebClient shopifyWebClient(WebClient.Builder builder, ShopifyProperties properties) {
+        return builder
+                .baseUrl(properties.getApiBaseUrl())
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("X-Shopify-Access-Token", properties.getAccessToken())
+                .build();
+    }
+}

--- a/Importacion_Etiquetas_Envio/src/main/java/org/tfg/importacion/config/ShopifyProperties.java
+++ b/Importacion_Etiquetas_Envio/src/main/java/org/tfg/importacion/config/ShopifyProperties.java
@@ -1,0 +1,89 @@
+package org.tfg.importacion.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.net.URI;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "shopify.api")
+public class ShopifyProperties {
+
+    private String key;
+    private String secret;
+
+    @NotEmpty
+    private List<String> scopes;
+
+    private URI redirectUri;
+
+    @NotBlank
+    private String shop;
+
+    private String accessToken;
+
+    @NotBlank
+    private String apiVersion;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public URI getRedirectUri() {
+        return redirectUri;
+    }
+
+    public void setRedirectUri(URI redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+
+    public String getShop() {
+        return shop;
+    }
+
+    public void setShop(String shop) {
+        this.shop = shop;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getApiBaseUrl() {
+        return "https://" + shop + "/admin/api/" + apiVersion;
+    }
+}

--- a/Importacion_Etiquetas_Envio/src/main/resources/application.properties
+++ b/Importacion_Etiquetas_Envio/src/main/resources/application.properties
@@ -1,0 +1,20 @@
+spring.application.name=Importacion_Etiquetas_Envio
+
+# Logging configuration
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.springframework.security=DEBUG
+logging.level.org.example.demo=INFO
+logging.level.root=INFO
+
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
+spring.jpa.open-in-view=false
+
+# Shopify configuration
+shopify.api.key=
+shopify.api.secret=
+shopify.api.scopes=read_orders,write_fulfillments,read_locations
+shopify.api.redirect-uri=http://localhost:8889/shopify/callback
+shopify.api.shop=Alhamas.myshopify.com
+shopify.api.access-token=
+shopify.api.api-version=2024-04


### PR DESCRIPTION
## Summary
- add the Spring Boot entry point and configuration classes for Shopify client wiring
- bind Shopify Admin API settings via `ShopifyProperties` with validation helpers
- provide default application properties with updated OAuth scopes and API version

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68de1e9cf7a48323964c162516e30780